### PR TITLE
TDP-264: Add Manual Approval Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# DevOps-Pod-B-May2024-SHALI-terraform
-The SHALI project aims to establish a secure, high-availability logging system for Timedelta. Utilizing AWS, Terraform, Ansible, Splunk, and GitHub Actions, it automates provisioning and deployment, ensuring comprehensive monitoring and secure log storage. Delivered by DevOps-Pod-B-May2024 Team.
+# Public Test
+


### PR DESCRIPTION
Wrote a new job for Terraform Apply that requires a manual Approval from reviewer before deploying to the Sandbox Environment.